### PR TITLE
Export MoonIllumination struct Values

### DIFF
--- a/suncalc.go
+++ b/suncalc.go
@@ -254,9 +254,9 @@ func GetMoonPosition(date time.Time, lat float64, lng float64) MoonPosition {
 }
 
 type MoonIllumination struct {
-	fraction float64
-	phase    float64
-	angle    float64
+	Fraction float64
+	Phase    float64
+	Angle    float64
 }
 
 // calculations for illumination parameters of the moon,


### PR DESCRIPTION
The title says it all. This is so the values can be referenced externally.